### PR TITLE
feat: add OMBI_INSTALL_METHOD environment variable

### DIFF
--- a/build/templater/debian/ombi.service
+++ b/build/templater/debian/ombi.service
@@ -7,6 +7,7 @@ User=ombi
 Group=nogroup
 WorkingDirectory=/opt/Ombi/
 ExecStart=/opt/Ombi/Ombi --storage /etc/Ombi/
+Environment=OMBI_INSTALL_METHOD=apt
 Type=simple
 TimeoutStopSec=30
 Restart=on-failure


### PR DESCRIPTION
This is in relation to the pull request I am opening in the Ombi repo as it is needed for the update fix to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to specify the installation method used during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->